### PR TITLE
(fix): fix checking python system version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ from codecs import open
 
 from setuptools import setup
 
-if sys.version < '3.8':
-    print("This version is not supported.")
+if sys.version_info < (3, 8):
+    print('This version is not supported')
     sys.exit(1)
 
 with open('README.rst') as f:
@@ -23,7 +23,7 @@ setup(
     version='0.5.3',
     url='http://www.github.com/sk364/codechef-cli',
     keywords="codechefcli codechef cli programming competitive-programming competitive-coding",
-    license='GNU','MIT',
+    license='GNU',
     author='Sachin Kukreja',
     author_email='skad5455@gmail.com',
     description='CodeChef Command Line Interface',


### PR DESCRIPTION
This PR fixes the `This version is not supported` issue while building the package.

Actually, `sys.version` return something like `3.11.4 (main, Jun 20 2023, 17:23:00) [Clang 14.0.3 (clang-1403.0.22.14.1)]` 
and comparing the above with a string `'3.8'` always returns false if the version if greater than `3.8`.
Whereas, `sys.version_info` returns a tuple similar to `sys.version_info(major=3, minor=11, micro=4, releaselevel='final', serial=0)` which makes sense comparing it to something like `(3,8)`.